### PR TITLE
Bug Fix: Geometric Series Formula Inconsistency

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -169,7 +169,6 @@ function addWithCapEfficiency(a, cap, strength = 2) {
 
 function sumGeometricSeries(base, rate, n, owned = 0) {
     base *= rate ** owned;
-    if (n == 1) return base;
     return base * (1 - rate ** n) / (1 - rate);
 }
 function maxGeometricSeries(base, rate, amount, owned = 0) {

--- a/js/util.js
+++ b/js/util.js
@@ -170,7 +170,7 @@ function addWithCapEfficiency(a, cap, strength = 2) {
 function sumGeometricSeries(base, rate, n, owned = 0) {
     base *= rate ** owned;
     if (n == 1) return base;
-    return base * (1 - rate ** (n + 1)) / (1 - rate);
+    return base * (1 - rate ** n) / (1 - rate);
 }
 function maxGeometricSeries(base, rate, amount, owned = 0) {
     base *= rate ** owned;


### PR DESCRIPTION
  Problem

  The sumGeometricSeries and maxGeometricSeries functions in js/util.js are not inverses of each other, causing incorrect upgrade cost calculations.

  Root cause: sumGeometricSeries uses rate ** (n + 1) instead of rate ** n, calculating one extra term than intended.

```
  // Current (buggy)
  return base * (1 - rate ** (n + 1)) / (1 - rate);

  // Fixed
  return base * (1 - rate ** n) / (1 - rate);
```

  Example

  For a card with levelCost: [10, 2] (base=10, rate=2):

  | Levels | Expected Cost | Current Cost | maxGeometricSeries        |
  |--------|---------------|--------------|---------------------------|
  | 1      | 10            | 10           | ✓                         |
  | 2      | 30            | 70           | Says 2 affordable with 30 |
  | 3      | 70            | 150          | Says 3 affordable with 70 |

  Impact on Autobuy

  This mismatch causes autobuy to fail silently, especially noticeable with low balance currencies:
  1. getCardLevelMax calculates player can afford N levels
  2. levelUpCard calculates cost for N levels using buggy formula (too high)
  3. Affordability check fails → no purchase happens
  4. Currencies appear "deleted" because expected upgrades never occur

  Affected Areas

  - Card level upgrades (manual & autobuy)
  - Cost display in tooltips, popups, and collection UI

  All costs will be lower after this fix, as players were previously being overcharged.
  
  Addresses #41 