### PR TITLE
Fix Auto Buy bug (#41)

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -68,17 +68,16 @@ function onFrame() {
             autobuyTime -= autobuyCount;
             let upgradedAny = false;
             for (let elm of tabs.collection.cardList) {
+                if (autobuyCount <= 0) break;
                 let [pack, rarity, id] = elm;
-                let canBought = getCardLevelMax(pack, rarity, id);
-                console.log("Buying", canBought, "of", pack, rarity, id);
-                if (canBought > 0) {
-                    canBought = Math.min(canBought, autobuyCount);
-                    autobuyCount -= canBought;
-                    game.stats.autobuyBought += canBought;
-                    levelUpCard(pack, rarity, id, canBought, false, false);
+                let levelsToBuy = Math.min(getCardLevelMax(pack, rarity, id), autobuyCount);
+                if (levelsToBuy > 0) {
+                    console.log("Buying", levelsToBuy, "of", pack, rarity, id);
+                    autobuyCount -= levelsToBuy;
+                    game.stats.autobuyBought += levelsToBuy;
+                    levelUpCard(pack, rarity, id, levelsToBuy, false, false);
                     upgradedAny = true;
                 }
-                if (autobuyCount <= 0) break;
             }
             if (upgradedAny) {
                 updateEffects();


### PR DESCRIPTION
I tested locally, and this should resolve #41

The Auto Buy was trying to buy 0 copies of a card when the framerate was very fast and `autobuyCount` was zero. When calculating the card cost, it was passing 0 as the amount bought. This would end up returning the base cost for the card. So the cost was subtracted, and the amount bought -- zero -- was added to the levels.

I moved the break from the `for` loop to the start. If we have no autobuy count, we shouldn't attempt to buy anything.
I also moved the console.log to after `canBought` (now `levelsToBuy` because I think that name is clearer) 